### PR TITLE
Switch redundant `ec2_home' to `java_home'

### DIFF
--- a/src/ec2nodefinder.app.src
+++ b/src/ec2nodefinder.app.src
@@ -24,6 +24,6 @@
         {cert, "PUT cert-filepath here"},
         {ping_timeout_sec, 60},
         {ec2_home, "/usr"},
-        {ec2_home, "/usr/lib/jvm/java-6-openjdk-amd64/jre"}
+        {java_home, "/usr/lib/jvm/java-6-openjdk-amd64/jre"}
         ]}]}.
 


### PR DESCRIPTION
The app's config accidentally has a duplicate `ec2_home` property
where a `java_home` was probably meant.